### PR TITLE
Modification to make the module run on QLM/LRZ pylab with noise mode

### DIFF
--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -69,7 +69,7 @@ class MyQLMBackend(object):
         if qpu is None:
             qpu = get_default_qpu()
         self.qpu = qpu
-        self.all_qubts = True if mode=="all_qubits" else False
+        self.all_qubits = True if mode=="all_qubits" else False
 
         if job_type == "SAMPLE":
             if observable is not None:
@@ -124,7 +124,7 @@ class MyQLMBackend(object):
             if complex_def.is_output():
                 output_complex_register_dict[complex_def.name()] = cast(List[List[complex]], list())
 
-        compiled_circuit = myqlm_call_circuit(circuit, self.number_qubits, self.all_qubts)
+        compiled_circuit = myqlm_call_circuit(circuit, self.number_qubits, self.all_qubits)
 
         if self.observable is None:
             job = compiled_circuit.to_job(job_type='SAMPLE',

--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -23,7 +23,7 @@ from qoqo_myqlm.interface import myqlm_call_circuit
 import numpy as np
 import warnings
 import qat
-from qat.qpus import get_default_qpu
+from qat.qpus import get_default_qpu ,LinAlg
 
 
 class MyQLMBackend(object):
@@ -65,7 +65,7 @@ class MyQLMBackend(object):
         self.device = device
         self.job_type = job_type
         if qpu is None:
-            qpu = get_default_qpu()
+            qpu = LinAlg()
         self.qpu = qpu
 
         if job_type == "SAMPLE":

--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -40,7 +40,8 @@ class MyQLMBackend(object):
                  device: Optional[Any] = None,  # noqa
                  job_type: str = "SAMPLE",
                  observable: Optional[np.ndarray] = None,
-                 qpu: Any = None) -> None:  # noqa
+                 qpu: Any = None,
+                 all_qubits: bool = False) -> None:  # noqa
         """Initialize MyQLM Backend
 
         Args:
@@ -67,6 +68,7 @@ class MyQLMBackend(object):
         if qpu is None:
             qpu = get_default_qpu()
         self.qpu = qpu
+        self.all_qubts = all_qubits
 
         if job_type == "SAMPLE":
             if observable is not None:
@@ -121,7 +123,7 @@ class MyQLMBackend(object):
             if complex_def.is_output():
                 output_complex_register_dict[complex_def.name()] = cast(List[List[complex]], list())
 
-        compiled_circuit = myqlm_call_circuit(circuit, self.number_qubits)
+        compiled_circuit = myqlm_call_circuit(circuit, self.number_qubits, self.all_qubts)
 
         if self.observable is None:
             job = compiled_circuit.to_job(job_type='SAMPLE',

--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -23,7 +23,7 @@ from qoqo_myqlm.interface import myqlm_call_circuit
 import numpy as np
 import warnings
 import qat
-from qat.qpus import get_default_qpu ,LinAlg
+from qat.qpus import get_default_qpu
 
 
 class MyQLMBackend(object):
@@ -65,7 +65,7 @@ class MyQLMBackend(object):
         self.device = device
         self.job_type = job_type
         if qpu is None:
-            qpu = LinAlg()
+            qpu = get_default_qpu()
         self.qpu = qpu
 
         if job_type == "SAMPLE":
@@ -137,7 +137,7 @@ class MyQLMBackend(object):
         result = self.qpu.submit(job)
         for sample in result:
             array = [qubit_state for qubit_state in sample.state]
-            output_bit_register_dict['ro'].append(array)
+            output_bit_register_dict[list(output_bit_register_dict.keys())[0]].append(array)
 
         return output_bit_register_dict, output_float_register_dict, output_complex_register_dict
 

--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -41,7 +41,7 @@ class MyQLMBackend(object):
                  job_type: str = "SAMPLE",
                  observable: Optional[np.ndarray] = None,
                  qpu: Any = None,
-                 all_qubits: bool = False) -> None:  # noqa
+                 mode: str = "parallelization_blocks") -> None:  # noqa
         """Initialize MyQLM Backend
 
         Args:
@@ -56,6 +56,7 @@ class MyQLMBackend(object):
             observable: if "OBS" is selected as the job type, this is the matrix of
                         the observable to measure.
             qpu: QPU machine to use (quantum processor or simulator) with relevant keywords
+            mode: noise mode, can be active_qubits_only, parallelization_blocks, all_qubits
 
         Raises:
             TypeError: Job_type specified is neither 'SAMPLE' nor 'OBS'
@@ -68,7 +69,7 @@ class MyQLMBackend(object):
         if qpu is None:
             qpu = get_default_qpu()
         self.qpu = qpu
-        self.all_qubts = all_qubits
+        self.all_qubts = True if mode=="all_qubits" else False
 
         if job_type == "SAMPLE":
             if observable is not None:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -47,7 +47,7 @@ def myqlm_call_circuit(
         
         elif "PragmaLoop" in op.tags():
             number_of_repetitions = max(0,int(op.repetitions().value))
-            for _ in range(number_of_repetitions+1):
+            for _ in range(number_of_repetitions):
                 for op_loop in op.circuit():
                     instructions = myqlm_call_operation(op_loop, qureg)
                     if instructions is not None:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -19,12 +19,10 @@ from typing import (
 import qat.lang.AQASM as qlm
 
 
-
-
 def myqlm_call_circuit(
         circuit: Circuit,
         number_qubits: int,
-        all_qubits: bool = False,
+        noise_mode_all_qubits: bool = False,
         **kwargs) -> qlm.Program:
     """Translate the qoqo circuit into MyQLM ouput
 
@@ -52,26 +50,18 @@ def myqlm_call_circuit(
                     instructions = myqlm_call_operation(op_loop, qureg)
                     if instructions is not None:
                         myqlm_program.apply(*instructions)
-                        if all_qubits:
+                        if noise_mode_all_qubits:
                             apply_I_on_inactive_qubits(number_qubits, myqlm_program, qureg, op_loop, instructions)
 
         else:
             instructions = myqlm_call_operation(op, qureg)
             if instructions is not None:
                 myqlm_program.apply(*instructions)
-                if all_qubits:
+                if noise_mode_all_qubits:
                     apply_I_on_inactive_qubits(number_qubits, myqlm_program, qureg, op, instructions)
 
 
     myqlm_circuit = myqlm_program.to_circ()
-    # for op in circuit:
-    #     if 'PragmaLoop' in op.tags():
-    #         for op_loop in op.circuit():
-    #             print(op_loop)
-    #     else:
-    #         print(op)
-    # for op in myqlm_circuit.iterate_simple():
-    #    print(op)
     return myqlm_circuit
 
 def apply_I_on_inactive_qubits(number_qubits, myqlm_program, qureg, op_loop, instructions):

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -64,6 +64,12 @@ def myqlm_call_circuit(
 
 
     myqlm_circuit = myqlm_program.to_circ()
+    # for op in circuit:
+    #     if 'PragmaLoop' in op.tags():
+    #         for op_loop in op.circuit():
+    #             print(op_loop)
+    #     else:
+    #         print(op)
     # for op in myqlm_circuit.iterate_simple():
     #    print(op)
     return myqlm_circuit

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -42,7 +42,7 @@ def myqlm_call_circuit(
     number_of_repetitions = 1
     for op in circuit:
         if "PragmaLoop" in op.tags():
-            number_of_repetitions = int(op.repetitions().value)
+            number_of_repetitions = max(1,int(op.repetitions().value))
 
     for _ in range(number_of_repetitions):
         for op in circuit:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -123,6 +123,8 @@ def myqlm_call_operation(
         pass
     elif 'PragmaLoop' in tags:
         pass
+    elif 'PragmaSetNumberOfMeasurements' in tags:
+        pass
     else:
         raise RuntimeError(f'Operation not in MyQLM backend tags={tags}')
 

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -41,20 +41,23 @@ def myqlm_call_circuit(
     for op in circuit:
         if 'PragmaActiveReset' in op.tags():
             myqlm_program.reset(op.involved_qubits)
-        else:
-            if "PragmaLoop" in op.tags():
-                number_of_repetitions = max(1,int(op.repetitions().value))
+        
+        elif "PragmaLoop" in op.tags():
+            number_of_repetitions = max(1,int(op.repetitions().value))
+            for _ in range(number_of_repetitions):
                 for op_loop in op.circuit():
-                    for _ in range(number_of_repetitions):
-                        instructions = myqlm_call_operation(op_loop, qureg)
-                        if instructions is not None:
-                            myqlm_program.apply(*instructions)
+                    instructions = myqlm_call_operation(op_loop, qureg)
+                    if instructions is not None:
+                        myqlm_program.apply(*instructions)
 
-            else:
-                instructions = myqlm_call_operation(op, qureg)
-                if instructions is not None:
-                    myqlm_program.apply(*instructions)
+        else:
+            instructions = myqlm_call_operation(op, qureg)
+            if instructions is not None:
+                myqlm_program.apply(*instructions)
 
+    # circuit = myqlm_program.to_circ()
+    # for op in circuit.iterate_simple():
+    #    print(op)
     myqlm_circuit = myqlm_program.to_circ()
 
     return myqlm_circuit

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -53,7 +53,7 @@ def myqlm_call_circuit(
                     if all_qubits:
                         # add an identity gate to all qubits but the ones involved in the operation
                         for qubit in range(number_qubits):
-                            if qubit not in [op_loop.qubit()]:
+                            if hasattr(op_loop, "qubit") and qubit not in [op_loop.qubit()]:
                                 myqlm_program.apply(qlm.I, qureg[qubit])
 
         else:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -115,7 +115,11 @@ def myqlm_call_operation(
         pass
     elif 'PragmaRepeatedMeasurement' in tags:
         pass
+    elif 'PragmaOperation' in tags:
+        pass
+    elif 'PragmaLoop' in tags:
+        pass
     else:
-        raise RuntimeError('Operation not in MyQLM backend')
+        raise RuntimeError(f'Operation not in MyQLM backend tags={tags}')
 
     return op

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -46,8 +46,8 @@ def myqlm_call_circuit(
             myqlm_program.reset(op.involved_qubits)
         
         elif "PragmaLoop" in op.tags():
-            number_of_repetitions = max(1,int(op.repetitions().value))
-            for _ in range(number_of_repetitions):
+            number_of_repetitions = max(0,int(op.repetitions().value))
+            for _ in range(number_of_repetitions+1):
                 for op_loop in op.circuit():
                     instructions = myqlm_call_operation(op_loop, qureg)
                     if instructions is not None:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -22,6 +22,7 @@ import qat.lang.AQASM as qlm
 def myqlm_call_circuit(
         circuit: Circuit,
         number_qubits: int,
+        all_qubits: bool = False,
         **kwargs) -> qlm.Program:
     """Translate the qoqo circuit into MyQLM ouput
 
@@ -49,6 +50,11 @@ def myqlm_call_circuit(
                     instructions = myqlm_call_operation(op_loop, qureg)
                     if instructions is not None:
                         myqlm_program.apply(*instructions)
+                    if all_qubits:
+                        # add an identity gate to all qubits but the ones involved in the operation
+                        for qubit in range(number_qubits):
+                            if qubit not in [op_loop.qubit()]:
+                                myqlm_program.apply(qlm.I, qureg[qubit])
 
         else:
             instructions = myqlm_call_operation(op, qureg)
@@ -133,6 +139,8 @@ def myqlm_call_operation(
     elif 'PragmaGlobalPhase' in tags:
         pass
     elif 'PragmaStopDecompositionBlock' in tags:
+        pass
+    elif 'PragmaStopParallelBlock' in tags:
         pass
     else:
         raise RuntimeError(f'Operation not in MyQLM backend tags={tags}')

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -38,7 +38,7 @@ def myqlm_call_circuit(
         qlm.Program: translated circuit
     """
     myqlm_program = qlm.Program()
-    qureg = myqlm_program.qalloc(number_qubits)    
+    qureg = myqlm_program.qalloc(number_qubits)
     for op in circuit:
         if 'PragmaActiveReset' in op.tags():
             myqlm_program.reset(op.involved_qubits)
@@ -54,6 +54,9 @@ def myqlm_call_circuit(
                         # add an identity gate to all qubits but the ones involved in the operation
                         for qubit in range(number_qubits):
                             if hasattr(op_loop, "qubit") and qubit not in [op_loop.qubit()]:
+                                myqlm_program.apply(qlm.I, qureg[qubit])
+                            elif hasattr(op_loop, "control") and hasattr(op_loop, "target")  and\
+                                qubit not in [op_loop.control(),op_loop.target()]:
                                 myqlm_program.apply(qlm.I, qureg[qubit])
 
         else:

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -38,14 +38,20 @@ def myqlm_call_circuit(
     """
     myqlm_program = qlm.Program()
     qureg = myqlm_program.qalloc(number_qubits)
-
+    # search for a PragmaLoop, and set the number of repetitions
+    number_of_repetitions = 1
     for op in circuit:
-        if 'PragmaActiveReset' in op.tags():
-            myqlm_program.reset(op.involved_qubits)
-        else:
-            instructions = myqlm_call_operation(op, qureg)
-            if instructions is not None:
-                myqlm_program.apply(*instructions)
+        if "PragmaLoop" in op.tags():
+            number_of_repetitions = int(op.repetitions().value)
+
+    for _ in range(number_of_repetitions):
+        for op in circuit:
+            if 'PragmaActiveReset' in op.tags():
+                myqlm_program.reset(op.involved_qubits)
+            else:
+                instructions = myqlm_call_operation(op, qureg)
+                if instructions is not None:
+                    myqlm_program.apply(*instructions)
 
     myqlm_circuit = myqlm_program.to_circ()
 
@@ -114,8 +120,6 @@ def myqlm_call_operation(
     elif 'Definition' in tags:
         pass
     elif 'PragmaRepeatedMeasurement' in tags:
-        pass
-    elif 'PragmaOperation' in tags:
         pass
     elif 'PragmaLoop' in tags:
         pass

--- a/qoqo_myqlm/interface/myqlm_interface.py
+++ b/qoqo_myqlm/interface/myqlm_interface.py
@@ -113,6 +113,8 @@ def myqlm_call_operation(
         pass
     elif 'Definition' in tags:
         pass
+    elif 'PragmaRepeatedMeasurement' in tags:
+        pass
     else:
         raise RuntimeError('Operation not in MyQLM backend')
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name='qoqo_myqlm',
       author_email='info@quantumsimulations.de',
       url='https://quantumsimulations.de',
       license=License,
-      python_requires='==3.8,==3.10',
+      python_requires='>=3.8.*, !=3.9.*, !=3.11.*',
       install_requires=install_requires,
       )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name='qoqo_myqlm',
       author_email='info@quantumsimulations.de',
       url='https://quantumsimulations.de',
       license=License,
-      python_requires='>=3.8.*, !=3.9.*, !=3.11.*',
+      python_requires='>=3.8.*,  !=3.11.*', #!=3.9.*,
       install_requires=install_requires,
       )


### PR DESCRIPTION
Main changes:
- python requirement in setup.py: pylab has only python 3.9 as kernel. This version was excluded in the main branch version, had to remove the exclusion. (Not sure this break anything, in my experience it didn`t) (@kbarkhqs  of this one maybe you know better)
- Noise mode: this is a necessary new addition, just for the case all_qubits where to "coerce" the QLM simulation into applying noise to all qubits not involved in the gate the circuits needs to be filled of identity gates parallel to the actual gates used in the QOQO circuit. There might be a clever way to accomplish this, but from QLM side it doesn`t look like they contemplate this noise mode.
- Added the PragmaLoop routine to unroll the loop section of a circuit.
- Added few more cases of ignored tags.