### PR TITLE
upgrade to qoqo 1.10 + fix issue with VariableMSXX gate conversion to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.4.7
+
+* Fix issue with VariableMSXX gate conversion. Update to qoqo 1.10
+
 ## 0.4.6
 
 * Update to qoqo 1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "qoqo_myqlm"
-version = "0.4.6"
+version = "0.4.7"
 description = "An inteface to execute circuits from QOQO to MYQLM"
 authors = [{name="HQS Quantum Simulation GmbH", email="info@quantumsimulations.de"}]
 readme = "README.md"
 requires-python = ">3.8, <3.11"
 dependencies = [
-    "qoqo>=1.4",
+    "qoqo>=1.10",
     'qoqo_calculator_pyo3>=1.1',
     "numpy",
     'myqlm'

--- a/qoqo_myqlm/__init__.py
+++ b/qoqo_myqlm/__init__.py
@@ -11,6 +11,7 @@ and Creates a MyQLM file with MyQLMBackend.
     MyQLMBackend
 
 """
+
 # Copyright © 2019-2021 HQS Quantum Simulations GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -22,9 +23,18 @@ and Creates a MyQLM file with MyQLMBackend.
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-from qoqo_myqlm.interface import myqlm_call_operation, myqlm_call_circuit
+from qoqo_myqlm.interface import (
+    myqlm_call_operation,
+    myqlm_call_circuit,
+    generate_VariableMSXX_matrix,
+)
 from qoqo_myqlm.backend import (
     MyQLMBackend,
 )
 
-__all__ = ("myqlm_call_operation", "myqlm_call_circuit", "MyQLMBackend")
+__all__ = (
+    "myqlm_call_operation",
+    "myqlm_call_circuit",
+    "MyQLMBackend",
+    "generate_VariableMSXX_matrix",
+)

--- a/qoqo_myqlm/backend/myqlm_backend.py
+++ b/qoqo_myqlm/backend/myqlm_backend.py
@@ -1,5 +1,6 @@
 """Backend producing MyQLM"""
-# Copyright © 2019-2021 HQS Quantum Simulations GmbH. All Rights Reserved.
+
+# Copyright © 2019-2024 HQS Quantum Simulations GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -178,7 +179,8 @@ class MyQLMBackend(object):
         )
 
     def run_measurement_registers(
-        self, measurement: Any  # noqa
+        self,
+        measurement: Any,  # noqa
     ) -> Tuple[
         Dict[str, List[List[bool]]],
         Dict[str, List[List[float]]],

--- a/qoqo_myqlm/interface/utilities.py
+++ b/qoqo_myqlm/interface/utilities.py
@@ -1,5 +1,4 @@
-"""MyQLM interface for qoqo operations and circuits."""
-# Copyright © 2019-2021 HQS Quantum Simulations GmbH. All Rights Reserved.
+# Copyright © 2019-2024 HQS Quantum Simulations GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -10,11 +9,19 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
+import numpy as np
 
-from qoqo_myqlm.interface.myqlm_interface import (
-    myqlm_call_operation,
-    myqlm_call_circuit,
-)
-from qoqo_myqlm.interface.utilities import generate_VariableMSXX_matrix
 
-__all__ = ("myqlm_call_operation", "myqlm_call_circuit", "generate_VariableMSXX_matrix")
+def generate_VariableMSXX_matrix(theta):
+    cos_component = np.cos(theta / 2)
+    sin_component = -1j * np.sin(theta / 2)
+    U = np.array(
+        [
+            [cos_component, 0, 0, sin_component],
+            [0, cos_component, sin_component, 0],
+            [0, sin_component, cos_component, 0],
+            [sin_component, 0, 0, cos_component],
+        ]
+    )
+
+    return U

--- a/tests/backend/test_myqlm_backend.py
+++ b/tests/backend/test_myqlm_backend.py
@@ -16,27 +16,21 @@ import numpy as np
 import numpy.testing as npt
 from qoqo import operations as ops
 from qoqo import Circuit
-from qoqo_myqlm import (
-    MyQLMBackend
-)
+from qoqo_myqlm import MyQLMBackend
 import math
-from qoqo_calculator_pyo3 import (
-    CalculatorFloat,
-    Calculator
-)
+from qoqo_calculator_pyo3 import CalculatorFloat, Calculator
 
 
 def test_myqlm_backend():
     """Testing the MyQLM functionality with the MyQLM backend"""
     circuit = Circuit()
-    circuit += ops.DefinitionBit(name='ro', length=2, is_output=True)
+    circuit += ops.DefinitionBit(name="ro", length=2, is_output=True)
     circuit += ops.RotateZ(qubit=0, theta=0)
     circuit += ops.PauliX(qubit=1)
-    circuit += ops.MeasureQubit(qubit=0, readout='ro', readout_index=0)
-    circuit += ops.MeasureQubit(qubit=1, readout='ro', readout_index=1)
+    circuit += ops.MeasureQubit(qubit=0, readout="ro", readout_index=0)
+    circuit += ops.MeasureQubit(qubit=1, readout="ro", readout_index=1)
 
-    backend = MyQLMBackend(number_qubits=2,
-                           number_measurements=5)
+    backend = MyQLMBackend(number_qubits=2, number_measurements=5)
 
     # (bit_dict, float_dict, complex_dict) = backend.run_circuit(circuit)
     # npt.assert_equal(float_dict, dict())
@@ -44,5 +38,5 @@ def test_myqlm_backend():
     # npt.assert_equal(bit_dict['ro'], [np.array([0., 1.])] * 5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/interface/test_myqlm_interface.py
+++ b/tests/interface/test_myqlm_interface.py
@@ -1,4 +1,5 @@
 """Test MyQLM interface"""
+
 # Copyright © 2019-2021 HQS Quantum Simulations GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -16,32 +17,51 @@ import numpy as np
 import numpy.testing as npt
 from qoqo import operations as ops
 from qoqo import Circuit
-from qoqo_myqlm import myqlm_call_circuit, myqlm_call_operation
+from qoqo_myqlm import (
+    myqlm_call_circuit,
+    myqlm_call_operation,
+    generate_VariableMSXX_matrix,
+)
 import qat.lang.AQASM as qlm
 
 qubits = qlm.Program().qalloc(2)
 
 
-@pytest.mark.parametrize("gate", [
-    (ops.RotateX(0, -np.pi), [qlm.RX(-np.pi), qubits[0]]),
-    (ops.RotateY(0, -np.pi), [qlm.RY(-np.pi), qubits[0]]),
-    (ops.RotateZ(0, -np.pi), [qlm.RZ(-np.pi), qubits[0]]),
-    (ops.CNOT(1, 0), [qlm.CNOT, qubits[1], qubits[0]]),
-    (ops.Hadamard(0), [qlm.H, qubits[0]]),
-    (ops.PauliX(0), [qlm.X, qubits[0]]),
-    (ops.PauliY(0), [qlm.Y, qubits[0]]),
-    (ops.PauliZ(0), [qlm.Z, qubits[0]]),
-    (ops.SGate(0), [qlm.S, qubits[0]]),
-    (ops.TGate(0), [qlm.T, qubits[0]]),
-    (ops.ControlledPauliY(1, 0), [qlm.Y.ctrl(), qubits[1], qubits[0]]),
-    (ops.ControlledPauliZ(1, 0), [qlm.CSIGN, qubits[1], qubits[0]]),
-    (ops.MeasureQubit(0, 'ro', 0), None),
-    (ops.DefinitionBit('ro', 1, False), None)
-])
+@pytest.mark.parametrize(
+    "gate",
+    [
+        (ops.RotateX(0, -np.pi), [qlm.RX(-np.pi), qubits[0]]),
+        (ops.RotateY(0, -np.pi), [qlm.RY(-np.pi), qubits[0]]),
+        (ops.RotateZ(0, -np.pi), [qlm.RZ(-np.pi), qubits[0]]),
+        (ops.CNOT(1, 0), [qlm.CNOT, qubits[1], qubits[0]]),
+        (ops.Hadamard(0), [qlm.H, qubits[0]]),
+        (ops.PauliX(0), [qlm.X, qubits[0]]),
+        (ops.PauliY(0), [qlm.Y, qubits[0]]),
+        (ops.PauliZ(0), [qlm.Z, qubits[0]]),
+        (ops.SGate(0), [qlm.S, qubits[0]]),
+        (ops.TGate(0), [qlm.T, qubits[0]]),
+        (ops.ControlledPauliY(1, 0), [qlm.Y.ctrl(), qubits[1], qubits[0]]),
+        (ops.ControlledPauliZ(1, 0), [qlm.CSIGN, qubits[1], qubits[0]]),
+        (ops.MeasureQubit(0, "ro", 0), None),
+        (ops.DefinitionBit("ro", 1, False), None),
+        (
+            ops.VariableMSXX(1, 0, theta=0.0245044),
+            [
+                qlm.AbstractGate(
+                    "VariableMSXX",
+                    [float],
+                    arity=2,
+                    matrix_generator=generate_VariableMSXX_matrix,
+                )(0.0245044),
+                qubits[1],
+                qubits[0],
+            ],
+        ),
+    ],
+)
 def test_gate_translation(gate):
     """Test gate operations with MyQLM interface"""
-    myqlm_operation = myqlm_call_operation(operation=gate[0],
-                                           qureg=qubits)
+    myqlm_operation = myqlm_call_operation(operation=gate[0], qureg=qubits)
 
     assert myqlm_operation == gate[1]
 
@@ -49,25 +69,27 @@ def test_gate_translation(gate):
 def test_circuit_translation():
     """Test translation of a full circuit with MyQLM interface"""
     circuit = Circuit()
-    circuit += ops.DefinitionBit('ro', is_output=True, length=2)
+    circuit += ops.DefinitionBit("ro", is_output=True, length=2)
     circuit += ops.Hadamard(qubit=0)
-    circuit += ops.RotateX(qubit=1, theta=np.pi/2)
+    circuit += ops.RotateX(qubit=1, theta=np.pi / 2)
     circuit += ops.CNOT(control=0, target=1)
-    circuit += ops.MeasureQubit(qubit=0, readout='ro', readout_index=0)
-    circuit += ops.MeasureQubit(qubit=1, readout='ro', readout_index=1)
+    circuit += ops.MeasureQubit(qubit=0, readout="ro", readout_index=0)
+    circuit += ops.MeasureQubit(qubit=1, readout="ro", readout_index=1)
 
     myqlm_program = qlm.Program()
     qubits = myqlm_program.qalloc(2)
     myqlm_program.apply(qlm.H, qubits[0])
-    myqlm_program.apply(qlm.RX(np.pi/2), qubits[1])
+    myqlm_program.apply(qlm.RX(np.pi / 2), qubits[1])
     myqlm_program.apply(qlm.CNOT, qubits[0], qubits[1])
     myqlm_circuit = myqlm_program.to_circ()
 
     translated_circuit = myqlm_call_circuit(circuit=circuit, number_qubits=2)
 
-    for op_trans, op_orig in zip(translated_circuit.iterate_simple(), myqlm_circuit.iterate_simple()):
+    for op_trans, op_orig in zip(
+        translated_circuit.iterate_simple(), myqlm_circuit.iterate_simple()
+    ):
         assert op_trans == op_orig
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
VariableMSXX is not part of myqml gates set; so initially the idea was to extract, for every occurence of this gate in the qoqo circuit, its associated unitary matrix and use this to define a gate in myqml.
I.e. it would be handle by the case of generic `TwoQubitGateOperation`.
But it seems this way does not work, and myqml instead decide to collect all instance and define them as a single gate (meaning all VariableMSXX have the same unitary matrix). This is wrong of course, since is a parametric gate.

In order to fix that I declare this gate as paramatetric defing the function to get the matrix given the theta. 
Tests with quantum program seems to show that the issue is fixed.
